### PR TITLE
Use PG::Connection.quote_ident to defend against using user-input as the key to the with clause

### DIFF
--- a/lib/ctes_in_my_pg.rb
+++ b/lib/ctes_in_my_pg.rb
@@ -91,7 +91,7 @@ module ActiveRecord
             when ActiveRecord::Relation, Arel::SelectManager
               select = Arel::Nodes::SqlLiteral.new "(#{expression.to_sql})"
             end
-            Arel::Nodes::As.new Arel::Nodes::SqlLiteral.new("\"#{name.to_s}\""), select
+            Arel::Nodes::As.new Arel::Nodes::SqlLiteral.new(PG::Connection.quote_ident(name.to_s)), select
           end
         when Arel::Nodes::As
           with_value

--- a/test/ctes_in_my_pg_test.rb
+++ b/test/ctes_in_my_pg_test.rb
@@ -29,6 +29,11 @@ describe 'Common Table Expression queries' do
       query = Person.with(testing: arel_manager)
       query.to_sql.must_equal 'WITH "testing" AS (SELECT "test"."foo" FROM "test") SELECT "people".* FROM "people"'
     end
+
+    it 'correctly quotes the identifiers' do
+        query = Person.with( '"DROP DATABASE test;' => Person.where(lucky_number: 7))
+        query.to_sql.must_equal 'WITH """DROP DATABASE test;" AS (SELECT "people".* FROM "people" WHERE "people"."lucky_number" = 7) SELECT "people".* FROM "people"'
+    end
   end
 
   describe '.with(common_table_exression_arel_nodes_as)' do


### PR DESCRIPTION
Recently at @Betterment, we discovered a low-impact SQL injection vulnerability in the CTE alias functionality of ctes_in_my_pg. The surface area is fairly small, and would only be an issue if you were using unsanitized user input as the hash key to a `with` clause. Nonetheless, it seems like a worthwhile thing to patch, especially since we already have the `pg` dependency in this project.

The actual change is to use the `PG::Connection.quote_ident`(1) instead of trying to add the double quotes around the identifier manually. This has better support for special characters which should prevent a possible SQLi.

1: http://www.rubydoc.info/gems/pg/PG/Connection:quote_ident