### PR TITLE
chore(rails 6): drop arel to support rails 6

### DIFF
--- a/ctes_in_my_pg.gemspec
+++ b/ctes_in_my_pg.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'pg'
   spec.add_dependency 'activerecord', '>= 5.2.0'
-  spec.add_dependency 'arel', '>= 7.0.0'
 
   spec.add_development_dependency 'm'
   spec.add_development_dependency 'database_cleaner'


### PR DESCRIPTION
Fixes #3 

I guess, to follow what was done for 5-2-0, this would just be pulled in as a new branch in the main project.